### PR TITLE
New options and harvest API upgrade to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ harvest:
   email:     'email@example.com'
   password:  'password'
   subdomain: 'company'
-  round_in_minutes: 30 # defaults to 15
+  use_timetrap_rounding: false # if set to true, use timetrap's computation (disables round_in_minutes option)
+  round_in_minutes: 30 # defaults to timetrap computation
   aliases:
     code:   '[project id] [task id]'
     design: '[project id] [task id]'

--- a/lib/timetrap_harvest/config.rb
+++ b/lib/timetrap_harvest/config.rb
@@ -24,6 +24,10 @@ class TimetrapHarvest::Config
     config['subdomain']
   end
 
+  def use_timetrap_rounding
+    config['use_timetrap_rounding'] || false
+  end
+
   def round_in_minutes
     config['round_in_minutes'] || DEFAULT_ROUND_IN_MINUTES
   end

--- a/lib/timetrap_harvest/config.rb
+++ b/lib/timetrap_harvest/config.rb
@@ -29,7 +29,11 @@ class TimetrapHarvest::Config
   end
 
   def alias_config(code)
-    if config = aliases[code]
+    config = (code.nil? && aliases.has_key?('default_task')) ?
+      aliases['default_task'] :
+      aliases[code]
+
+    if config
       config = config.split(' ')
 
       { project_id: config.first, task_id: config.last }

--- a/lib/timetrap_harvest/config.rb
+++ b/lib/timetrap_harvest/config.rb
@@ -2,6 +2,7 @@ class TimetrapHarvest::Config
   MissingHarvestConfig     = Class.new(StandardError)
   MissingHarvestAliases    = Class.new(StandardError)
   MissingHarvestSubdomain  = Class.new(StandardError)
+  MissingHarvestV2Config   = Class.new(StandardError)
   DEFAULT_ROUND_IN_MINUTES = 15
 
   attr_reader :timetrap_config
@@ -10,12 +11,14 @@ class TimetrapHarvest::Config
     @timetrap_config = timetrap_config
   end
 
-  def email
-    config['email']
+  def token
+    ensure_v2!
+
+    config['token']
   end
 
-  def password
-    config['password']
+  def account_id
+    config['account_id']
   end
 
   def subdomain
@@ -54,6 +57,10 @@ class TimetrapHarvest::Config
     ensure_config!
 
     timetrap_config['harvest']
+  end
+
+  def ensure_v2!
+    fail(MissingHarvestV2Config, 'Missing harvest credentials for API v2 in .timetrap.yml config file') if config['token'].nil? || config['account_id'].nil?
   end
 
   def ensure_config!

--- a/lib/timetrap_harvest/formatter.rb
+++ b/lib/timetrap_harvest/formatter.rb
@@ -11,7 +11,7 @@ class TimetrapHarvest::Formatter
   def format
     if alias_config && entry[:end]
       { notes:      entry[:note],
-        hours:      hours_for_time(entry[:start], entry[:end]),
+        hours:      hours_for_time,
         project_id: project_id.to_i,
         task_id:    task_id.to_i,
         spent_at:   entry[:start].strftime('%Y%m%d')
@@ -37,23 +37,27 @@ class TimetrapHarvest::Formatter
     config.alias_config(code)
   end
 
-  def round_in_minutes
-    config.round_in_minutes
-  end
-
   def code
     if match = HARVESTABLE_REGEX.match(entry[:note])
       code = match[1]
     end
   end
 
-  def hours_for_time(start_time, end_time)
-    minutes = (end_time - start_time) / 60
+  def hours_for_time
+    if config.use_timetrap_rounding
+      return entry.duration.to_f / 3600
+    end
+
+    minutes = (entry[:end] - entry[:start]) / 60
     rounded = round(minutes)
     hours   = (rounded / 60)
   end
 
   def round(value, nearest = round_in_minutes)
     (value % nearest).zero? ? value : (value + nearest) - (value % nearest)
+  end
+
+  def round_in_minutes
+    config.round_in_minutes
   end
 end

--- a/lib/timetrap_harvest/formatter.rb
+++ b/lib/timetrap_harvest/formatter.rb
@@ -10,11 +10,15 @@ class TimetrapHarvest::Formatter
 
   def format
     if alias_config && entry[:end]
-      { notes:      entry[:note],
-        hours:      hours_for_time,
-        project_id: project_id.to_i,
-        task_id:    task_id.to_i,
-        spent_at:   entry[:start].strftime('%Y%m%d')
+      { notes:              entry[:note],
+        hours:              hours_for_time,
+        project_id:         project_id.to_i,
+        task_id:            task_id.to_i,
+        spent_date:         entry[:start].strftime('%Y-%m-%d'),
+        external_reference: {
+          id: "timetrap-#{entry.sheet}-#{entry.id}",
+          permalink: "http://timetrap.local"
+        }
       }
     elsif !entry[:end]
       { error: 'Entry not ended yet', note: entry[:note] }

--- a/lib/timetrap_harvest/harvester.rb
+++ b/lib/timetrap_harvest/harvester.rb
@@ -11,8 +11,8 @@ class TimetrapHarvest::Harvester
       if result.key? :error
         failed << result
       else
-        client.post(result)
-
+        id = client.fetch(result)
+        client.create_or_update(id, result)
         submitted << result
       end
     end

--- a/lib/timetrap_harvest/network_client.rb
+++ b/lib/timetrap_harvest/network_client.rb
@@ -3,27 +3,50 @@ require 'json'
 require 'uri'
 
 class TimetrapHarvest::NetworkClient
-  attr_reader :email, :password, :subdomain
+  attr_reader :token, :account_id
 
   def initialize(config)
-    @email     = config.email
-    @password  = config.password
-    @subdomain = config.subdomain
+    @token     = config.token
+    @account_id = config.account_id
   end
 
-  def post(payload)
-    req = Net::HTTP::Post.new(harvest_add_uri.request_uri)
-    req.basic_auth(email, password)
+  def fetch(payload)
+    uri = harvest_entries_uri
+    params = { external_reference_id: payload[:external_reference][:id] }
+    uri.query = URI.encode_www_form(params)
+
+    req = Net::HTTP::Get.new(uri)
+    res = request(uri, req)
+
+    return if !res.is_a?(Net::HTTPSuccess)
+
+    json = JSON.parse(res.body)
+    return if json['total_entries'] == 0
+    json['time_entries'][0]['id']
+  end
+
+  def create_or_update(id, payload)
+    uri = harvest_entries_uri
+    req = id.nil? ?
+      Net::HTTP::Post.new(uri) :
+      Net::HTTP::Patch.new(URI.join(uri, id.to_s))
     req.body            = payload.to_json
     req['Content-Type'] = 'application/json'
     req['Accept']       = 'application/json'
 
-    res = Net::HTTP.start(harvest_add_uri.hostname, harvest_add_uri.port, use_ssl: true) do |http|
-      http.request(req)
-    end
+    request(uri, req)
   end
 
-  def harvest_add_uri
-    URI("https://#{subdomain}.harvestapp.com/daily/add")
+  def harvest_entries_uri
+    URI("https://api.harvestapp.com/v2/time_entries/")
+  end
+
+  def request(uri, req)
+    req["Authorization"] = "Bearer #{token}"
+    req['Harvest-Account-ID'] = account_id
+
+    http = Net::HTTP.new(uri.hostname, uri.port)
+    http.use_ssl = true
+    http.request(req)
   end
 end

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -4,7 +4,7 @@ require 'ostruct'
 
 describe 'HarvestFormatter' do
   def fake_entry(options = {})
-    OpenStruct.new(options)
+    OpenStruct.new(options.merge(id: 50, sheet: 'test'))
   end
 
   describe '#format' do
@@ -26,8 +26,6 @@ describe 'HarvestFormatter' do
         end:   start + 60 * 60
       )
 
-      options = { project_id: '1234', task_id: '4321' }
-
       formatter = TimetrapHarvest::Formatter.new(entry, config)
 
       expect(formatter.format).to include({
@@ -35,7 +33,8 @@ describe 'HarvestFormatter' do
         hours: 1,
         project_id: 1234,
         task_id: 4321,
-        spent_at: '20140617'
+        spent_date: '2014-06-17',
+        external_reference: { id: 'timetrap-test-50', permalink: 'http://timetrap.local' }
       })
     end
 
@@ -48,8 +47,6 @@ describe 'HarvestFormatter' do
         end:   start + 10 * 60
       )
 
-      options = { project_id: '1234', task_id: '4321', round_in_minutes: 15 }
-
       formatter = TimetrapHarvest::Formatter.new(entry, config)
 
       expect(formatter.format).to include({
@@ -57,7 +54,8 @@ describe 'HarvestFormatter' do
         hours: 0.25,
         project_id: 1234,
         task_id: 4321,
-        spent_at: '20140617'
+        spent_date: '2014-06-17',
+        external_reference: { id: 'timetrap-test-50', permalink: 'http://timetrap.local' }
       })
     end
   end
@@ -82,17 +80,15 @@ describe 'HarvestFormatter' do
         duration: 7200 # timetrap's computation
       )
 
-      options = { project_id: '1234', task_id: '4321' }
-
       formatter = TimetrapHarvest::Formatter.new(entry, config)
 
-      $debug = true
       expect(formatter.format).to include({
         notes: entry[:note],
         hours: 2,
         project_id: 1234,
         task_id: 4321,
-        spent_at: '20140617'
+        spent_date: '2014-06-17',
+        external_reference: { id: 'timetrap-test-50', permalink: 'http://timetrap.local' }
       })
     end
   end

--- a/spec/timetrap_harvest_spec.rb
+++ b/spec/timetrap_harvest_spec.rb
@@ -19,7 +19,8 @@ describe 'Timetrap::Formatters::Harvest' do
 
       formatter.config = config
 
-      expect(fake_client).to receive(:post)
+      expect(fake_client).to receive(:fetch)
+      expect(fake_client).to receive(:create_or_update)
       expect(formatter.output).to include('Submitted: working on stuff @design')
     end
 
@@ -48,7 +49,8 @@ describe 'Timetrap::Formatters::Harvest' do
         })
 
 
-        expect(fake_client).to receive(:post).with(any_args)
+        expect(fake_client).to receive(:fetch)
+        expect(fake_client).to receive(:create_or_update)
         expect(formatter.output).to include('Submitted: 1')
       end
     end


### PR DESCRIPTION
3 things:
- A default_task 'magic' code that handles entries that weren't properly tagged (optional)
- Add option to let timetrap gem calculate duration (there are sometimes discrepancies between what timetrap will give with the `-r` formatting option and this plugin's rounding)
- Use harvest's v2 api and the `external_reference` arg to avoid pushing the same entry twice and enable edits to be pushed